### PR TITLE
修复由windows自带编辑器设置user_id_list.txt的一些问题

### DIFF
--- a/weiboSpider.py
+++ b/weiboSpider.py
@@ -944,7 +944,7 @@ class Weibo(object):
         """更新用户配置文件"""
         with open(user_config_file_path, 'rb') as f:
             lines = f.read().splitlines()
-            lines = [line.decode('utf-8') for line in lines]
+            lines = [line.decode('utf-8-sig') for line in lines]
             for i, line in enumerate(lines):
                 info = line.split(' ')
                 if len(info) > 0 and info[0].isdigit():
@@ -1020,7 +1020,7 @@ class Weibo(object):
         with open(file_name, 'rb') as f:
             try:
                 lines = f.read().splitlines()
-                lines = [line.decode('utf-8') for line in lines]
+                lines = [line.decode('utf-8-sig') for line in lines]
             except UnicodeDecodeError:
                 sys.exit(u'%s文件应为utf-8编码，请先将文件编码转为utf-8再运行程序' % file_name)
             user_config_list = []


### PR DESCRIPTION
由windows自带编辑器设置user_id_list.txt可能会使文本内容前被自动加上一个\ufeff字符，从而使程序出问题，将utf-8替换为utf-8-sig可忽略该字符，也保证程序对utf-8编码的检测顺利