### PR TITLE
将 MySQL 库建表语句的正文长度上限提高到 5000

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ config.json
 
 weibo/
 *.log
+
+.idea

--- a/weibo_spider/writer/mysql_writer.py
+++ b/weibo_spider/writer/mysql_writer.py
@@ -85,7 +85,7 @@ class MySqlWriter(Writer):
                 CREATE TABLE IF NOT EXISTS weibo (
                 id varchar(10) NOT NULL,
                 user_id varchar(12),
-                content varchar(2000),
+                content varchar(5000),
                 article_url varchar(200),
                 original_pictures varchar(3000),
                 retweet_pictures varchar(3000),


### PR DESCRIPTION
爬取微博过程中出现若干个 pymysql.err.DataError: (1406, "Data too long for column 'content' at row 1")