### PR TITLE
feature: 增加kafka writer，支持向kafka实时推送爬取的数据

### DIFF
--- a/weibo_spider/config_sample.json
+++ b/weibo_spider/config_sample.json
@@ -18,5 +18,10 @@
         "password": "123456",
         "charset": "utf8mb4"
     },
+    "kafka_config": {
+        "bootstrap-server": "127.0.0.1:9092",
+        "weibo_topics": ["spider_weibo"],
+        "user_topics": ["spider_weibo"]
+    },
     "sqlite_config": "weibo.db"
 }

--- a/weibo_spider/config_util.py
+++ b/weibo_spider/config_util.py
@@ -85,14 +85,14 @@ def validate_config(config):
                 sys.exit()
 
     # 验证write_mode
-    write_mode = ['txt', 'csv', 'json', 'mongo', 'mysql', 'sqlite']
+    write_mode = ['txt', 'csv', 'json', 'mongo', 'mysql', 'sqlite', 'kafka']
     if not isinstance(config['write_mode'], list):
         logger.warning(u'write_mode值应为list类型')
         sys.exit()
     for mode in config['write_mode']:
         if mode not in write_mode:
             logger.warning(
-                u'%s为无效模式，请从txt、csv、json、mongo、sqlite和mysql中挑选一个或多个作为write_mode',
+                u'%s为无效模式，请从txt、csv、json、mongo、sqlite, kafka和mysql中挑选一个或多个作为write_mode',
                 mode)
             sys.exit()
 

--- a/weibo_spider/spider.py
+++ b/weibo_spider/spider.py
@@ -67,7 +67,7 @@ class Spider:
         self.mysql_config = config.get('mysql_config')  # MySQL数据库连接配置，可以不填
 
         self.sqlite_config = config.get('sqlite_config')
-
+        self.kafka_config = config.get('kafka_config')
         self.user_config_file_path = ''
         user_id_list = config['user_id_list']
         if FLAGS.user_id_list:
@@ -237,6 +237,11 @@ class Spider:
             from .writer import SqliteWriter
 
             self.writers.append(SqliteWriter(self.sqlite_config))
+
+        if 'kafka' in self.write_mode:
+            from .writer import KafkaWriter
+
+            self.writers.append(KafkaWriter(self.kafka_config))
 
         self.downloaders = []
         if self.pic_download == 1:

--- a/weibo_spider/writer/__init__.py
+++ b/weibo_spider/writer/__init__.py
@@ -4,5 +4,6 @@ from .mongo_writer import MongoWriter
 from .mysql_writer import MySqlWriter
 from .txt_writer import TxtWriter
 from .sqlite_writer import SqliteWriter
+from .kafka_writer import KafkaWriter
 
-__all__ = [CsvWriter, TxtWriter, JsonWriter, MongoWriter, MySqlWriter, SqliteWriter]
+__all__ = [CsvWriter, TxtWriter, JsonWriter, MongoWriter, MySqlWriter, SqliteWriter, KafkaWriter]

--- a/weibo_spider/writer/kafka_writer.py
+++ b/weibo_spider/writer/kafka_writer.py
@@ -4,7 +4,7 @@ import logging
 from kafka import KafkaProducer
 
 from .writer import Writer
-logger = logging.getLogger('spider.mysql_writer')
+logger = logging.getLogger('spider.kafka_writer')
 
 
 class KafkaWriter(Writer):
@@ -28,4 +28,3 @@ class KafkaWriter(Writer):
 
     def __del__(self):
         self.producer.close()
-

--- a/weibo_spider/writer/kafka_writer.py
+++ b/weibo_spider/writer/kafka_writer.py
@@ -1,0 +1,31 @@
+import json
+import logging
+
+from kafka import KafkaProducer
+
+from .writer import Writer
+logger = logging.getLogger('spider.mysql_writer')
+
+
+class KafkaWriter(Writer):
+
+    def __init__(self, kafka_config):
+        self.kafka_config = kafka_config
+        self.producer = KafkaProducer(bootstrap_servers=str(kafka_config['bootstrap-server']).split(','),
+                                 value_serializer=lambda m: json.dumps(m,ensure_ascii=False).encode('UTF-8'))
+        self.weibo_topics = list(kafka_config['weibo_topics'])
+        self.user_topics = list(kafka_config['user_topics'])
+        logger.info('{}', kafka_config)
+
+    def write_weibo(self, weibo):
+        for w in weibo:
+            for topic in self.weibo_topics:
+                self.producer.send(topic, value=w.__dict__)
+
+    def write_user(self, user):
+        for topic in self.user_topics:
+            self.producer.send(topic, value=user.__dict__)
+
+    def __del__(self):
+        self.producer.close()
+


### PR DESCRIPTION
由于我想做一个实时爬取微博消息主动推送的东西，所以增加了一个KafkaWriter，可以向消息队列写入数据，实时推送，配置内容如下：
```json
{
"kafka_config": {
        "bootstrap-server": "127.0.0.1:9092", #kafka地址, 集群用逗号分隔
        "weibo_topics": ["spider_weibo"], # 推送微博消息的topic
        "user_topics": ["spider_weibo"]  # 推送用户个人信息的topic
    }
}
```
个人能力有限，不足之处还望提出来，联系邮件: windlively@live.cn，望采纳。