### PR TITLE
fix(test data): 修复 Windows 系统下写入 Test Data 文件报错的问题

### DIFF
--- a/weibo_spider/parser/util.py
+++ b/weibo_spider/parser/util.py
@@ -29,7 +29,7 @@ def handle_html(cookie, url):
             import os
 
             resp_file = os.path.join(TEST_DATA_DIR, '%s.html' % hash_url(url))
-            with io.open(resp_file, 'w') as f:
+            with io.open(resp_file, 'w', encoding='utf-8') as f:
                 f.write(resp.text)
 
             with io.open(os.path.join(TEST_DATA_DIR, URL_MAP_FILE), 'r+') as f:


### PR DESCRIPTION
Windows 在配置 GENERATE_TEST_DATA 为 True 时执行程序会报错：
'gbk' codec can't encode character 'xxxx' in position xxxxxx: illegal multibyte sequence
原因是在 Windows 系统上，程序会将内容从 utf-8 编码转换为 gbk 编码，再写入文件。编码转换过程出现错误。