### PR TITLE
chore(gitignore): 忽略使用 SQLite 时生成的 weibo.db

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ dist/
 config.json
 
 weibo/
+weibo.db
 *.log
 
 .idea


### PR DESCRIPTION
默认配置文件将 SQLite 数据库文件名称配置为 weibo.db。应该忽略程序根据默认配置生成的文件。