### PR TITLE
更新MongoDB设置及相关文档

### DIFF
--- a/docs/settings.md
+++ b/docs/settings.md
@@ -178,6 +178,28 @@ $ pip install pymysql
 ```bash
 $ pip install pymongo
 ```
+connection_string是MongoDB标准URI：
+```text
+mongodb://[username:password@]host1[:port1][,...hostN[:portN]][/[defaultauthdb][?options]]
+```
+
+dba_name和dba_password对应URI中的username和password。如果没有访问限制可不填。
+无访问限制的例子：
+```json
+"connection_string": "mongodb://localhost:27017/weibo",
+```
+使用用户名和密码的例子：
+```json
+"connection_string": "mongodb://admin:password@localhost:27017/weibo",
+"dba_name": "",
+"dba_password": "",
+```
+或
+```json
+"connection_string": "mongodb://localhost:27017/weibo",
+"dba_name": "admin",
+"dba_password": "password",
+```
 
 MySQL和MongDB数据库的写入内容一样。程序首先会创建一个名为"weibo"的数据库，然后再创建"user"表和"weibo"表，包含爬取的所有内容。爬取到的微博**用户信息**或插入或更新，都会存储到user表里；爬取到的**微博信息**或插入或更新，都会存储到weibo表里，两个表通过user_id关联。如果想了解两个表的具体字段，请点击"详情"。
 

--- a/weibo_spider/config_sample.json
+++ b/weibo_spider/config_sample.json
@@ -26,8 +26,8 @@
     },
     "sqlite_config": "weibo.db",
     "mongo_config": {
-        "connection_string": "mongodb://test:testpwd@localhost:27017/weibo",
-        "dba_name": "admin",
-        "dba_password": "password"
+        "connection_string": "mongodb://admin:password@localhost:27017/weibo",
+        "dba_name": "",
+        "dba_password": ""
     }
 }

--- a/weibo_spider/writer/mongo_writer.py
+++ b/weibo_spider/writer/mongo_writer.py
@@ -11,8 +11,8 @@ class MongoWriter(Writer):
     def __init__(self, mongo_config):
         self.mongo_config = mongo_config
         self.connection_string = mongo_config['connection_string']
-        self.dba_name = mongo_config['dba_name']
-        self.dba_password = mongo_config['dba_password']
+        self.dba_name = mongo_config.get('dba_name', None)
+        self.dba_password = mongo_config.get('dba_password', None)
 
     def _info_to_mongodb(self, collection, info_list):
         """将爬取的信息写入MongoDB数据库"""
@@ -26,8 +26,11 @@ class MongoWriter(Writer):
             from pymongo import MongoClient
 
             client = MongoClient(self.connection_string)
-            if not self.dba_name.isspace() or not self.dba_password.isspace():
-                client.admin.authenticate(self.dba_name,self.dba_password,mechanism='SCRAM-SHA-1')
+            if self.dba_name or self.dba_password:
+                # authenticate() 在PyMongo3.6版本就已弃用，这一段可能需要后续跟进
+                client.admin.authenticate(
+                    self.dba_name, self.dba_password, mechanism='SCRAM-SHA-1'
+                )
 
             db = client['weibo']
             collection = db[collection]


### PR DESCRIPTION
另外：authenticate()方法在PyMongo3.6版本就已弃用，本人不是很确定使用authenticate()的必要性，这一部分可能还需要后续改动。
PyMongo changlog如下：

> Deprecated authenticate(). Authenticating multiple users conflicts with support for logical sessions in MongoDB 3.6. To authenticate as multiple users, create multiple instances of [MongoClient](https://pymongo.readthedocs.io/en/stable/api/pymongo/mongo_client.html#pymongo.mongo_client.MongoClient).