### PR TITLE
Fix the crawling of toutiao article urls.

### DIFF
--- a/weibo_spider/parser/page_parser.py
+++ b/weibo_spider/parser/page_parser.py
@@ -75,7 +75,7 @@ class PageParser(Parser):
                         publish_time = datetime_util.str_to_time(
                             weibo.publish_time)
 
-                        if publish_time < since_date:                            
+                        if publish_time < since_date:
                             # As of 2023.05, there can be at most 2 pinned weibo.
                             # We will continue for at most 2 times before return.
                             if self.page == 1 and cur_pinned_count < MAX_PINNED_COUNT:
@@ -158,9 +158,9 @@ class PageParser(Parser):
         """获取微博头条文章的url"""
         article_url = ''
         text = handle_garbled(info)
-        if text.startswith(u'发布了头条文章'):
+        if text.startswith(u'发布了头条文章') or text.startswith(u'我发表了头条文章'):
             url = info.xpath('.//a/@href')
-            if url and url[0].startswith('https://weibo.cn/sinaurl'):
+            if url and url[0].startswith('https://weibo.com/ttarticle'):
                 article_url = url[0]
         return article_url
 


### PR DESCRIPTION
Fix #518.

主要是两个修改：
1. 通过搜索“头条文章”，我们发现有两种可能的文本“发布了头条文章”或“我发表了头条文章”
2. 通过查看相应的链接，我们发现头条文章现在的url形式为 https://weibo.com/ttarticle/

已使用以下user id做了测试：
1. 6045161833 
NgvSY9mW7,我发表了头条文章:《《小城人物志（2）》》 《小城人物志（2）》  ,https://weibo.com/ttarticle/p/show?id=2309404939358200529130 ,无,无,True,无,无,2023-08-27 14:36,李小李的iPhone 11,0,0,0

2. 1955190431
Ng2CODhDi,发布了头条文章：《關於不實報道的重要申明澄清》  關於不實報道的重要申明澄清  ,https://weibo.com/ttarticle/p/show?id=2309404938233426608435 ,无,无,True,无,无,2023-08-24 12:07,微博 weibo.com,42,15,10

