### PR TITLE
解决 'NoneType' object has no attribute 'xpath'

### DIFF
--- a/weibo_spider/parser/page_parser.py
+++ b/weibo_spider/parser/page_parser.py
@@ -44,10 +44,11 @@ class PageParser(Parser):
         is_exist = ''
         for i in range(3):
             self.selector = handle_html(self.cookie, self.url)
-            info = self.selector.xpath("//div[@class='c']")
-            if info is None or len(info) == 0:
-                continue
-            is_exist = info[0].xpath("div/span[@class='ctt']")
+            if self.selector:
+                info = self.selector.xpath("//div[@class='c']")
+                if info is None or len(info) == 0:
+                    continue
+                is_exist = info[0].xpath("div/span[@class='ctt']")
             if is_exist:
                 PageParser.empty_count = 0
                 break


### PR DESCRIPTION
handle_html 函数返回 Element 或者 None，`page_parser.py` 没有处理 None 的情况
```py
'NoneType' object has no attribute 'xpath'
Traceback (most recent call last):
  File "C:\Users\zw\miniconda3\lib\site-packages\weibo_spider\spider.py", line 178, in get_weibo_info
    weibos, self.weibo_id_list, to_continue = PageParser(
  File "C:\Users\zw\miniconda3\lib\site-packages\weibo_spider\parser\page_parser.py", line 47, in __init__
    info = self.selector.xpath("//div[@class='c']")
AttributeError: 'NoneType' object has no attribute 'xpath'
```