### PR TITLE
Use the pypi index version of browser_cookie3 in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ lxml==4.9.1
 requests==2.32.0
 tqdm==4.66.3
 absl-py==0.12.0
-git+https://github.com/borisbabic/browser_cookie3.git@refs/pull/215/head
+browser_cookie3==0.20.1

--- a/weibo_spider/config_util.py
+++ b/weibo_spider/config_util.py
@@ -207,7 +207,7 @@ def check_cookie(user_config_file_path):
     """Checks if user is logged in"""
     try:
         cookie = get_cookie()
-        if cookie["MLOGIN"] == '0':
+        if cookie.get("MLOGIN", '0') == '0':
             logger.warning("使用 Chrome 在此登录 %s", "https://passport.weibo.com/sso/signin?entry=wapsso&source=wapssowb&url=https://m.weibo.cn/")
             sys.exit()
         else:


### PR DESCRIPTION
并且修复以下问题:

这里的 cookie 有可能不含 "MLOGIN" 这个 key，例如此时我未登录的 cookie 为：

```
{'SUB': '_2A25I0S7kDeRhGeVP6lET9yjJzjmIHXVrry4srDV6PUJbktANLWXAkW1NTU8PBZ0pWcKBCiA1prnv4RhE1j-P_CWd', 'SUBP': '0033WrSXqPxfM725Ws9jqgMF55529P9D9WhxVcpPFHOwH1VA0_OSa3CL5JpX5KzhUgL.FoepeKeES0qfSK-2dJLoI7R_TPW0IPxQUPiDMcX_TBtt'}
```

在这种情况下会抛异常：

```
Check for cookie failed: 'MLOGIN'
'MLOGIN'
Traceback (most recent call last):
  File "/Users/songzy/weiboSpider/weibo_spider/spider.py", line 387, in main
    config = _get_config()
  File "/Users/songzy/weiboSpider/weibo_spider/spider.py", line 376, in _get_config
    config_util.check_cookie(config_path)
  File "/Users/songzy/weiboSpider/weibo_spider/config_util.py", line 211, in check_cookie
    if cookie["MLOGIN"] == '0':
KeyError: 'MLOGIN'
```

可修正为
```
        if cookie.get("MLOGIN", '0') == '0':
```